### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM zenika/alpine-chrome:119-with-playwright
+LABEL org.opencontainers.image.source="https://github.com/dgtlmoon/sockpuppetbrowser"
 
 # docker build -t test .
 # docker run -it -v `pwd`:/tmp/server -i --init --cap-add=SYS_ADMIN test bash


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md