### PR TITLE
Adding timezone feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ LABEL org.opencontainers.image.source="https://github.com/dgtlmoon/sockpuppetbro
 USER root
 ENV PYTHONUNBUFFERED=1
 ENV LOG_LEVEL=DEBUG
-RUN apk add --update --no-cache python3 python3-dev musl-dev linux-headers xvfb xvfb-run openbox && ln -sf python3 /usr/bin/python
+ENV TZ="Etc/UTC"
+RUN apk add --update --no-cache python3 python3-dev musl-dev linux-headers xvfb xvfb-run openbox tzdata && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache --upgrade pip setuptools virtualenv

--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ docker run --rm --security-opt seccomp=$(pwd)/chrome.json -p 127.0.0.1:3000:3000
 
 `seccomp` security setting is _highly_ recommended https://github.com/Zenika/alpine-chrome?tab=readme-ov-file#-the-best-with-seccomp
 
+## Docker Compose Example
+
+```
+browser-sockpuppet-chrome:
+    hostname: browser-sockpuppet-chrome
+    image: dgtlmoon/sockpuppetbrowser:latest    
+    cap_add:
+      - SYS_ADMIN
+    restart: unless-stopped
+    environment:
+      - TZ=America/Toronto
+      - SCREEN_WIDTH=1920
+      - SCREEN_HEIGHT=1024
+      - SCREEN_DEPTH=16
+      - MAX_CONCURRENT_CHROME_PROCESSES=10    
+```
+
+## Setting Timezone
+
+Environment variable TZ has been added, along with tzdata package. The default value is: `Etc/UTC`.
+
+Timezone can be set as an environment variable, using a value from the time zone database:
+* [Wikipedia - List of TZ Database Time Zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+* [IANA - Time Zone Database](https://www.iana.org/time-zones)
+
+This can be verified to be passed into the Docker container in shell by running: `echo $TZ` and `date`.
+
 ### Headful Mode with Virtual Display
 
 By default, Chrome runs in headless mode for maximum performance. However, you can enable "headful" mode which runs Chrome with a virtual X server (Xvfb) for scenarios requiring visual rendering or when certain websites detect headless browsers.


### PR DESCRIPTION
Looking to address [this issue](https://github.com/dgtlmoon/sockpuppetbrowser/issues/27), requesting timezone support for changedetection. 

I'm relatively new to contributing code, so please let me know if I should be doing things differently.

**Changes:**

* Added tzdata apk to DOCKERFILE so it would be included in the image build.
* Added environment variable `ENV TZ="Etc/UTC"` to set a default timezone as UTC. This can be overridden by using an environment variable when launching the Docker container.
* Added documentation with explanation of timezone feature, and provided example docker compose YML.

**Tests:**
* Built the docker image locally, tagged, and [pushed to Dockerhub](https://hub.docker.com/repository/docker/linuxtekca/sockpuppetbrowser/general) for testing.
* Tested image on TrueNAS SCALE using Docker Compose.  Was able to update the timezone via environment variable.

**References:**
* [ChangeDetection.io Github](https://github.com/dgtlmoon/changedetection.io)
* [LinuxServer.io Page on ChangeDetection.io](https://docs.linuxserver.io/images/docker-changedetection.io)