### PR TITLE
Fix zombie Chrome processes by calling wait() after kill

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -328,6 +328,15 @@ async def cleanup_chrome_by_pid(chrome_process, user_data_dir="/tmp", time_at_st
                     proc.kill()  # SIGKILL immediately - no waiting
                 except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass
+            # Reap the main chrome process to prevent zombies
+            try:
+                loop = asyncio.get_event_loop()
+                await asyncio.wait_for(
+                    loop.run_in_executor(None, chrome_process.wait),
+                    timeout=5.0
+                )
+            except (asyncio.TimeoutError, Exception) as e:
+                logger.warning(f"WebSocket ID: {websocket.id} - Error reaping Chrome process: {str(e)}")
 
             logger.debug(f"WebSocket ID: {websocket.id} - Chrome PID {chrome_process.pid} cleanup signaled")
         except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):


### PR DESCRIPTION
## Problem
After killing Chrome child processes with SIGKILL, `cleanup_chrome_by_pid` 
never calls `wait()` on the process. This leaves them as zombie processes 
indefinitely since the parent (python3 server.py) stays alive and the OS 
cannot reap them.

This matches the error seen in issue #28:
`Error in Chrome cleanup: Passing coroutines is forbidden, use tasks explicitly.`

## Fix
Added `chrome_process.wait()` via `run_in_executor` after the kill loop,
following the same asyncio pattern already used throughout the file.

## Tested
Verified on Ubuntu 24.04 with Docker.  Zombie Chromium processes no longer 
accumulate after applying this patch.