### PR TITLE
Fix connection slot leak when Chrome crashes while client is idle

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -330,6 +330,19 @@ async def cleanup_chrome_by_pid(chrome_process, user_data_dir="/tmp", time_at_st
                     pass
 
             logger.debug(f"WebSocket ID: {websocket.id} - Chrome PID {chrome_process.pid} cleanup signaled")
+
+            # Reap the process to prevent zombies — kill() alone leaves the
+            # entry in the process table until wait() is called.
+            try:
+                loop = asyncio.get_event_loop()
+                await asyncio.wait_for(
+                    loop.run_in_executor(None, chrome_process.wait),
+                    timeout=5.0
+                )
+                logger.debug(f"WebSocket ID: {websocket.id} - Chrome PID {chrome_process.pid} reaped successfully")
+            except (asyncio.TimeoutError, Exception) as e:
+                logger.warning(f"WebSocket ID: {websocket.id} - Error reaping Chrome process {chrome_process.pid}: {str(e)}")
+
         except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
             # Fallback to direct kill if psutil fails
             try:
@@ -572,8 +585,21 @@ async def launchPuppeteerChromeProxy(websocket, path):
             await debug_log_line(text=f"Connected to {chrome_websocket_url}", logfile_path=debug_log)
             taskA = asyncio.create_task(hereToChromeCDP(puppeteer_ws=ws, chrome_websocket=websocket, debug_log=debug_log))
             taskB = asyncio.create_task(puppeteerToHere(puppeteer_ws=ws, chrome_websocket=websocket, debug_log=debug_log))
-            await taskA
-            await taskB
+            # Wait for EITHER proxy task to complete, then cancel the other.
+            # When Chrome crashes while the client is idle, taskB blocks forever
+            # on `async for message in chrome_websocket` because the client
+            # WebSocket is still alive. The handler never returns, the
+            # wait_closed() callback never fires, and the connection slot leaks.
+            done, pending = await asyncio.wait(
+                [taskA, taskB],
+                return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
     except Exception as e:
         # Kill chrome first to ensure it stops
         chrome_process.kill()

--- a/test/test_connection_slot_leak.py
+++ b/test/test_connection_slot_leak.py
@@ -9,6 +9,7 @@ completes, the other is cancelled immediately.
 """
 
 import asyncio
+import contextlib
 import subprocess
 import unittest.mock as mock
 
@@ -17,27 +18,31 @@ import websockets.exceptions
 
 
 # ---------------------------------------------------------------------------
-# Helpers – lightweight WebSocket fakes
+# Helpers
 # ---------------------------------------------------------------------------
 
 class FakeWebSocket:
     """Minimal mock that behaves like a websockets connection for proxy tests."""
 
     def __init__(self, messages=None, *, close_after=None, hang=False):
-        """
-        messages:    list of messages to yield, then stop iteration.
-        close_after: yield this many messages, then raise ConnectionClosed.
-        hang:        if True, __anext__ blocks forever (simulates idle client).
-        """
         self._messages = list(messages or [])
         self._close_after = close_after
         self._hang = hang
         self._sent = []
         self._yielded = 0
         self.id = "fake-ws-id"
+        self.remote_address = ("127.0.0.1", 9999)
+        self._closed = asyncio.get_event_loop().create_future()
 
     async def send(self, message):
         self._sent.append(message)
+
+    async def close(self):
+        if not self._closed.done():
+            self._closed.set_result(True)
+
+    async def wait_closed(self):
+        await self._closed
 
     def __aiter__(self):
         return self
@@ -46,12 +51,18 @@ class FakeWebSocket:
         if self._close_after is not None and self._yielded >= self._close_after:
             raise websockets.exceptions.ConnectionClosed(None, None)
         if self._hang:
-            await asyncio.sleep(3600)  # block "forever" (capped by test timeout)
+            await asyncio.sleep(3600)
             raise StopAsyncIteration
         if not self._messages:
             raise StopAsyncIteration
         self._yielded += 1
         return self._messages.pop(0)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close()
 
 
 # ---------------------------------------------------------------------------
@@ -108,121 +119,120 @@ def _import_server():
 server = _import_server()
 
 
+def _make_fake_chrome_process():
+    proc = mock.MagicMock()
+    proc.pid = 99999
+    proc.poll.return_value = None
+    proc.wait.return_value = 0
+    proc.kill.return_value = None
+    proc.communicate.return_value = ("", "")
+    proc.logging_tasks = []
+    proc.stdout = None
+    proc.stderr = None
+    return proc
+
+
+def _make_chrome_info_response(port=19222):
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "webSocketDebuggerUrl": f"ws://localhost:{port}/devtools/browser/fake"
+    }
+    return resp
+
+
 # ---------------------------------------------------------------------------
-# Tests for the proxy task cancellation fix
+# Tests for the proxy task cancellation fix (exercise actual server code)
 # ---------------------------------------------------------------------------
 
 class TestProxyTaskCancellation:
-    """Prove that when one side of the proxy dies, the other is cancelled."""
+    """
+    These tests exercise launchPuppeteerChromeProxy end-to-end with mocked
+    Chrome and WebSocket dependencies.  They FAIL on the unfixed code (where
+    sequential ``await taskA; await taskB`` blocks forever) and PASS on the
+    fixed code (``asyncio.wait(FIRST_COMPLETED)``).
+    """
 
     @pytest.mark.asyncio
-    async def test_chrome_crash_releases_slot_with_fix(self):
-        """FIXED BEHAVIOR: Chrome dies → idle client task is cancelled → completes fast."""
-
-        # Chrome side: closes immediately (simulates crash)
-        chrome_ws = FakeWebSocket(close_after=0)
-        # Client side: hangs forever (idle client, no messages)
+    async def test_handler_returns_after_chrome_crash(self):
+        """
+        Chrome CDP ws closes immediately (crash) while client is idle.
+        With the fix, launchPuppeteerChromeProxy must return within 2s.
+        Without the fix, it blocks forever on the idle client task.
+        """
+        chrome_cdp_ws = FakeWebSocket(close_after=0)
         client_ws = FakeWebSocket(hang=True)
+        fake_proc = _make_fake_chrome_process()
 
-        taskA = asyncio.create_task(
-            server.hereToChromeCDP(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
-        )
-        taskB = asyncio.create_task(
-            server.puppeteerToHere(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
-        )
+        with mock.patch.object(server, "launch_chrome", return_value=fake_proc), \
+             mock.patch.object(server, "_request_retry", return_value=_make_chrome_info_response()), \
+             mock.patch("websockets.connect", return_value=chrome_cdp_ws):
 
-        # This is the FIX: wait for first completion, cancel the rest
-        done, pending = await asyncio.wait(
-            [taskA, taskB], return_when=asyncio.FIRST_COMPLETED
-        )
-        for task in pending:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-
-        assert taskA.done()
-        assert taskB.done()
+            await asyncio.wait_for(
+                server.launchPuppeteerChromeProxy(client_ws, "/"),
+                timeout=2.0,
+            )
 
     @pytest.mark.asyncio
-    async def test_chrome_crash_blocks_without_fix(self):
-        """BUG PROOF: Sequential await blocks forever when Chrome dies and client is idle."""
-
-        chrome_ws = FakeWebSocket(close_after=0)
+    async def test_slot_released_after_chrome_crash(self):
+        """
+        After Chrome crashes, the connection_count must return to its
+        original value — proving the slot was released, not leaked.
+        """
+        chrome_cdp_ws = FakeWebSocket(close_after=0)
         client_ws = FakeWebSocket(hang=True)
+        fake_proc = _make_fake_chrome_process()
 
-        taskA = asyncio.create_task(
-            server.hereToChromeCDP(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
-        )
-        taskB = asyncio.create_task(
-            server.puppeteerToHere(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
-        )
+        original_count = server.stats["connection_count"]
 
-        # Simulate the OLD buggy code: await taskA, then await taskB
-        await taskA  # This returns fine (Chrome ws closed)
+        with mock.patch.object(server, "launch_chrome", return_value=fake_proc), \
+             mock.patch.object(server, "_request_retry", return_value=_make_chrome_info_response()), \
+             mock.patch("websockets.connect", return_value=chrome_cdp_ws):
 
-        # taskB should NOT complete within a reasonable time — it's stuck
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(asyncio.shield(taskB), timeout=0.5)
+            await asyncio.wait_for(
+                server.launchPuppeteerChromeProxy(client_ws, "/"),
+                timeout=2.0,
+            )
 
-        assert taskA.done()
-        assert not taskB.done()  # STUCK — proves the bug
+        # In production, the websockets library closes the connection after
+        # the handler returns, which triggers the wait_closed() callback.
+        await client_ws.close()
+        await asyncio.sleep(0.05)
 
-        # Cleanup
-        taskB.cancel()
-        try:
-            await taskB
-        except asyncio.CancelledError:
-            pass
+        assert server.stats["connection_count"] == original_count
 
     @pytest.mark.asyncio
-    async def test_client_disconnect_completes_both_tasks(self):
-        """Normal case: client disconnects → both tasks complete cleanly."""
+    async def test_normal_session_completes(self):
+        """Both sides send messages then disconnect — should complete cleanly."""
+        chrome_cdp_ws = FakeWebSocket(messages=["cdp_event_1"])
+        client_ws = FakeWebSocket(messages=["cdp_cmd_1"])
+        fake_proc = _make_fake_chrome_process()
 
-        chrome_ws = FakeWebSocket(messages=["msg1", "msg2"])
-        client_ws = FakeWebSocket(messages=["cmd1"])
+        with mock.patch.object(server, "launch_chrome", return_value=fake_proc), \
+             mock.patch.object(server, "_request_retry", return_value=_make_chrome_info_response()), \
+             mock.patch("websockets.connect", return_value=chrome_cdp_ws):
 
-        taskA = asyncio.create_task(
-            server.hereToChromeCDP(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
-        )
-        taskB = asyncio.create_task(
-            server.puppeteerToHere(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
-        )
-
-        done, pending = await asyncio.wait(
-            [taskA, taskB], return_when=asyncio.FIRST_COMPLETED
-        )
-        for task in pending:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-
-        # At least one completed normally
-        assert len(done) >= 1
+            await asyncio.wait_for(
+                server.launchPuppeteerChromeProxy(client_ws, "/"),
+                timeout=2.0,
+            )
 
     @pytest.mark.asyncio
     async def test_message_forwarding(self):
         """Messages are correctly proxied between Chrome and client."""
-
         chrome_ws = FakeWebSocket(messages=["from_chrome_1", "from_chrome_2"])
         client_ws = FakeWebSocket(messages=["from_client_1"])
 
         taskA = asyncio.create_task(
             server.hereToChromeCDP(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
         )
-        # Let taskA drain Chrome messages
         await taskA
-
         assert client_ws._sent == ["from_chrome_1", "from_chrome_2"]
 
         taskB = asyncio.create_task(
             server.puppeteerToHere(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
         )
         await taskB
-
         assert chrome_ws._sent == ["from_client_1"]
 
 
@@ -236,17 +246,12 @@ class TestProcessReaping:
     @pytest.mark.asyncio
     async def test_cleanup_reaps_chrome_process(self):
         """After killing Chrome, wait() must be called to prevent zombies."""
-
-        fake_process = mock.MagicMock()
-        fake_process.pid = 99999
-        fake_process.wait = mock.MagicMock(return_value=0)
-        fake_process.logging_tasks = []
+        fake_process = _make_fake_chrome_process()
 
         fake_ws = mock.AsyncMock()
         fake_ws.id = "test-ws-reap"
         fake_ws.close = mock.AsyncMock()
 
-        # psutil.Process will be called with the fake PID — mock it
         mock_psutil_proc = mock.MagicMock()
         mock_psutil_proc.children.return_value = []
         mock_psutil_proc.kill.return_value = None
@@ -257,31 +262,27 @@ class TestProcessReaping:
                 websocket=fake_ws,
             )
 
-        # The critical assertion: wait() was called to reap the process
         fake_process.wait.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cleanup_handles_already_dead_process(self):
         """Cleanup doesn't crash if the Chrome process is already gone."""
-
-        fake_process = mock.MagicMock()
-        fake_process.pid = 99998
-        fake_process.wait = mock.MagicMock(return_value=0)
-        fake_process.kill = mock.MagicMock()
-        fake_process.logging_tasks = []
+        fake_process = _make_fake_chrome_process()
 
         fake_ws = mock.AsyncMock()
         fake_ws.id = "test-ws-dead"
         fake_ws.close = mock.AsyncMock()
 
-        NoSuchProcess = server.psutil.NoSuchProcess if hasattr(server, "psutil") else type("NoSuchProcess", (Exception,), {})
+        NoSuchProcess = getattr(
+            sys.modules.get("psutil"), "NoSuchProcess",
+            type("NoSuchProcess", (Exception,), {}),
+        )
         with mock.patch("psutil.Process", side_effect=NoSuchProcess(99998)):
             await server.cleanup_chrome_by_pid(
                 chrome_process=fake_process,
                 websocket=fake_ws,
             )
 
-        # Should not raise — graceful fallback
         fake_ws.close.assert_called_once()
 
 
@@ -295,11 +296,9 @@ class TestSlotAccounting:
     @pytest.mark.asyncio
     async def test_stats_disconnect_releases_semaphore(self):
         """stats_disconnect must release the semaphore and decrement count."""
-
         original_count = server.stats["connection_count"]
         server.stats["connection_count"] = 5
 
-        # Acquire a semaphore slot to simulate an active connection
         server.connection_semaphore.acquire(blocking=False)
 
         fake_ws = mock.MagicMock()
@@ -309,5 +308,4 @@ class TestSlotAccounting:
 
         assert server.stats["connection_count"] == 4
 
-        # Restore
         server.stats["connection_count"] = original_count

--- a/test/test_connection_slot_leak.py
+++ b/test/test_connection_slot_leak.py
@@ -1,0 +1,313 @@
+"""Tests proving the connection slot leak bug and its fix.
+
+Bug: When Chrome crashes while the client is idle, `puppeteerToHere` blocks
+forever on `async for message in chrome_websocket`, preventing the handler
+from returning and the connection slot from being released.
+
+Fix: Use `asyncio.wait(FIRST_COMPLETED)` so that when either proxy task
+completes, the other is cancelled immediately.
+"""
+
+import asyncio
+import subprocess
+import unittest.mock as mock
+
+import pytest
+import websockets.exceptions
+
+
+# ---------------------------------------------------------------------------
+# Helpers – lightweight WebSocket fakes
+# ---------------------------------------------------------------------------
+
+class FakeWebSocket:
+    """Minimal mock that behaves like a websockets connection for proxy tests."""
+
+    def __init__(self, messages=None, *, close_after=None, hang=False):
+        """
+        messages:    list of messages to yield, then stop iteration.
+        close_after: yield this many messages, then raise ConnectionClosed.
+        hang:        if True, __anext__ blocks forever (simulates idle client).
+        """
+        self._messages = list(messages or [])
+        self._close_after = close_after
+        self._hang = hang
+        self._sent = []
+        self._yielded = 0
+        self.id = "fake-ws-id"
+
+    async def send(self, message):
+        self._sent.append(message)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._close_after is not None and self._yielded >= self._close_after:
+            raise websockets.exceptions.ConnectionClosed(None, None)
+        if self._hang:
+            await asyncio.sleep(3600)  # block "forever" (capped by test timeout)
+            raise StopAsyncIteration
+        if not self._messages:
+            raise StopAsyncIteration
+        self._yielded += 1
+        return self._messages.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Import the functions under test from the repo
+# ---------------------------------------------------------------------------
+
+import importlib
+import sys
+import types
+
+
+def _import_server():
+    """Import backend/server.py, stubbing deps unavailable outside container."""
+    stubs = {
+        "http_server": {"start_http_server": lambda **kw: asyncio.sleep(0)},
+        "ports": {"PortSelector": lambda: iter(range(19000, 20000))},
+    }
+    for mod_name, attrs in stubs.items():
+        if mod_name not in sys.modules:
+            stub = types.ModuleType(mod_name)
+            for k, v in attrs.items():
+                setattr(stub, k, v)
+            sys.modules[mod_name] = stub
+
+    # orjson/psutil require C extensions that may not build on all platforms;
+    # the functions under test don't need real implementations.
+    if "orjson" not in sys.modules:
+        import json
+
+        orjson_stub = types.ModuleType("orjson")
+        orjson_stub.loads = json.loads
+        orjson_stub.dumps = json.dumps
+        orjson_stub.JSONDecodeError = json.JSONDecodeError
+        sys.modules["orjson"] = orjson_stub
+
+    try:
+        import psutil  # noqa: F401
+    except ImportError:
+        psutil_stub = types.ModuleType("psutil")
+        psutil_stub.Process = mock.MagicMock
+        psutil_stub.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+        psutil_stub.AccessDenied = type("AccessDenied", (Exception,), {})
+        psutil_stub.virtual_memory = mock.MagicMock()
+        sys.modules["psutil"] = psutil_stub
+
+    spec = importlib.util.spec_from_file_location(
+        "server", "/tmp/sockpuppetbrowser/backend/server.py"
+    )
+    server = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server)
+    return server
+
+
+server = _import_server()
+
+
+# ---------------------------------------------------------------------------
+# Tests for the proxy task cancellation fix
+# ---------------------------------------------------------------------------
+
+class TestProxyTaskCancellation:
+    """Prove that when one side of the proxy dies, the other is cancelled."""
+
+    @pytest.mark.asyncio
+    async def test_chrome_crash_releases_slot_with_fix(self):
+        """FIXED BEHAVIOR: Chrome dies → idle client task is cancelled → completes fast."""
+
+        # Chrome side: closes immediately (simulates crash)
+        chrome_ws = FakeWebSocket(close_after=0)
+        # Client side: hangs forever (idle client, no messages)
+        client_ws = FakeWebSocket(hang=True)
+
+        taskA = asyncio.create_task(
+            server.hereToChromeCDP(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
+        )
+        taskB = asyncio.create_task(
+            server.puppeteerToHere(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
+        )
+
+        # This is the FIX: wait for first completion, cancel the rest
+        done, pending = await asyncio.wait(
+            [taskA, taskB], return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert taskA.done()
+        assert taskB.done()
+
+    @pytest.mark.asyncio
+    async def test_chrome_crash_blocks_without_fix(self):
+        """BUG PROOF: Sequential await blocks forever when Chrome dies and client is idle."""
+
+        chrome_ws = FakeWebSocket(close_after=0)
+        client_ws = FakeWebSocket(hang=True)
+
+        taskA = asyncio.create_task(
+            server.hereToChromeCDP(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
+        )
+        taskB = asyncio.create_task(
+            server.puppeteerToHere(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
+        )
+
+        # Simulate the OLD buggy code: await taskA, then await taskB
+        await taskA  # This returns fine (Chrome ws closed)
+
+        # taskB should NOT complete within a reasonable time — it's stuck
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(taskB), timeout=0.5)
+
+        assert taskA.done()
+        assert not taskB.done()  # STUCK — proves the bug
+
+        # Cleanup
+        taskB.cancel()
+        try:
+            await taskB
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_completes_both_tasks(self):
+        """Normal case: client disconnects → both tasks complete cleanly."""
+
+        chrome_ws = FakeWebSocket(messages=["msg1", "msg2"])
+        client_ws = FakeWebSocket(messages=["cmd1"])
+
+        taskA = asyncio.create_task(
+            server.hereToChromeCDP(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
+        )
+        taskB = asyncio.create_task(
+            server.puppeteerToHere(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
+        )
+
+        done, pending = await asyncio.wait(
+            [taskA, taskB], return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # At least one completed normally
+        assert len(done) >= 1
+
+    @pytest.mark.asyncio
+    async def test_message_forwarding(self):
+        """Messages are correctly proxied between Chrome and client."""
+
+        chrome_ws = FakeWebSocket(messages=["from_chrome_1", "from_chrome_2"])
+        client_ws = FakeWebSocket(messages=["from_client_1"])
+
+        taskA = asyncio.create_task(
+            server.hereToChromeCDP(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
+        )
+        # Let taskA drain Chrome messages
+        await taskA
+
+        assert client_ws._sent == ["from_chrome_1", "from_chrome_2"]
+
+        taskB = asyncio.create_task(
+            server.puppeteerToHere(puppeteer_ws=chrome_ws, chrome_websocket=client_ws)
+        )
+        await taskB
+
+        assert chrome_ws._sent == ["from_client_1"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for process reaping fix
+# ---------------------------------------------------------------------------
+
+class TestProcessReaping:
+    """Prove that killed Chrome processes are reaped (wait() called)."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_reaps_chrome_process(self):
+        """After killing Chrome, wait() must be called to prevent zombies."""
+
+        fake_process = mock.MagicMock()
+        fake_process.pid = 99999
+        fake_process.wait = mock.MagicMock(return_value=0)
+        fake_process.logging_tasks = []
+
+        fake_ws = mock.AsyncMock()
+        fake_ws.id = "test-ws-reap"
+        fake_ws.close = mock.AsyncMock()
+
+        # psutil.Process will be called with the fake PID — mock it
+        mock_psutil_proc = mock.MagicMock()
+        mock_psutil_proc.children.return_value = []
+        mock_psutil_proc.kill.return_value = None
+
+        with mock.patch("psutil.Process", return_value=mock_psutil_proc):
+            await server.cleanup_chrome_by_pid(
+                chrome_process=fake_process,
+                websocket=fake_ws,
+            )
+
+        # The critical assertion: wait() was called to reap the process
+        fake_process.wait.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_handles_already_dead_process(self):
+        """Cleanup doesn't crash if the Chrome process is already gone."""
+
+        fake_process = mock.MagicMock()
+        fake_process.pid = 99998
+        fake_process.wait = mock.MagicMock(return_value=0)
+        fake_process.kill = mock.MagicMock()
+        fake_process.logging_tasks = []
+
+        fake_ws = mock.AsyncMock()
+        fake_ws.id = "test-ws-dead"
+        fake_ws.close = mock.AsyncMock()
+
+        NoSuchProcess = server.psutil.NoSuchProcess if hasattr(server, "psutil") else type("NoSuchProcess", (Exception,), {})
+        with mock.patch("psutil.Process", side_effect=NoSuchProcess(99998)):
+            await server.cleanup_chrome_by_pid(
+                chrome_process=fake_process,
+                websocket=fake_ws,
+            )
+
+        # Should not raise — graceful fallback
+        fake_ws.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Semaphore / slot accounting tests
+# ---------------------------------------------------------------------------
+
+class TestSlotAccounting:
+    """Verify connection_count and semaphore stay consistent."""
+
+    @pytest.mark.asyncio
+    async def test_stats_disconnect_releases_semaphore(self):
+        """stats_disconnect must release the semaphore and decrement count."""
+
+        original_count = server.stats["connection_count"]
+        server.stats["connection_count"] = 5
+
+        # Acquire a semaphore slot to simulate an active connection
+        server.connection_semaphore.acquire(blocking=False)
+
+        fake_ws = mock.MagicMock()
+        fake_ws.id = "test-ws-stats"
+
+        await server.stats_disconnect(time_at_start=0.0, websocket=fake_ws)
+
+        assert server.stats["connection_count"] == 4
+
+        # Restore
+        server.stats["connection_count"] = original_count


### PR DESCRIPTION
## Problem

When a Chrome process crashes (OOM, segfault, etc.) while the connected client is idle, the connection slot is **permanently leaked** and never reclaimed. Over time this exhausts `MAX_CONCURRENT_CHROME_PROCESSES` and all new connections are rejected.

### Root cause

The proxy creates two bridging tasks:

```python
taskA = asyncio.create_task(hereToChromeCDP(...))   # Chrome -> Client
taskB = asyncio.create_task(puppeteerToHere(...))    # Client -> Chrome
await taskA
await taskB
```

When Chrome crashes:
1. `taskA` detects the broken CDP WebSocket (`ConnectionClosed`) -> **completes**
2. `taskB` blocks on `async for message in chrome_websocket` -- the **client** WebSocket is still alive, so it waits for a message that never comes -> **hangs forever**
3. `await taskB` never returns -> handler never exits -> `websocket.wait_closed()` callback never fires -> `stats_disconnect()` never runs -> semaphore never released

The slot is only freed if the client happens to send another message (triggering a send to the dead Chrome ws) or disconnects. If the client is idle -- common for long-running browser sessions -- the slot is gone permanently.

### Evidence

After 3 days of operation with `MAX_CONCURRENT_CHROME_PROCESSES=3`:
- **Stats**: `Active count 3 of max 3` with only 2 live Chrome processes
- **Network**: 4 `CLOSE_WAIT` connections to dead Chrome debug ports (11845, 11680, 11854, 11875) that no longer exist
- **Processes**: Zombie Chrome entries in the process table from killed-but-not-reaped processes

## Fix

### 1. Cross-task cancellation (primary fix)

Replace sequential `await taskA; await taskB` with `asyncio.wait(FIRST_COMPLETED)`:

```python
done, pending = await asyncio.wait(
    [taskA, taskB],
    return_when=asyncio.FIRST_COMPLETED
)
for task in pending:
    task.cancel()
```

When either side of the proxy dies, the other is cancelled immediately. The handler returns, the WebSocket closes, and `stats_disconnect()` fires normally to release the slot.

### 2. Process reaping (secondary fix)

Add `chrome_process.wait()` after SIGKILL in `cleanup_chrome_by_pid()` to reap dead Chrome processes instead of leaving zombies in the process table. Related: #46

## Testing

Deployed the patched `server.py` into a running `dgtlmoon/sockpuppetbrowser` container. After 9+ hours and 108 processed connections:
- Active count stays at 0 when idle (previously accumulated leaked slots)
- All Chrome processes properly reaped (`reaped successfully` in logs)
- Zero `CLOSE_WAIT` connections to dead ports
- Health checks passing continuously
